### PR TITLE
chore: centralize CI to shared reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+  security-events: write
+
 jobs:
   lint:
     name: Lint PHP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,3 @@ jobs:
       enable_cosign: true
       enable_release_drafter: true
     secrets: inherit
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,20 @@
 name: CI
 
-on:
+"on":
   push:
     branches: ["**"]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
+    name: Lint PHP
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -15,27 +22,14 @@ jobs:
           php-version: "8.2"
       - run: php -l day-of-year-calendar.php
 
-  build-image:
-    needs: [lint]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/day-of-year-calendar:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/day-of-year-calendar:latest
+  docker:
+    needs: lint
+    uses: mbologna/.github/.github/workflows/docker-build-scan-push.yml@main
+    with:
+      image_name: day-of-year-calendar
+      push_to_dockerhub: false
+      enable_grype: true
+      enable_cosign: true
+      enable_release_drafter: true
+    secrets: inherit
+


### PR DESCRIPTION
## Summary

Replaces the existing workflow(s) with thin callers into the shared reusable workflows at [mbologna/.github](https://github.com/mbologna/.github).



## What changed

- No logic lives in this repo anymore — all steps run from the central workflow
- Action SHAs, Trivy/Grype/Cosign versions, and trigger patterns are maintained in one place
- Future updates (new scanner, action version bump) only need a single PR in `mbologna/.github`